### PR TITLE
changed typo "ec2acess" to "ec2access"

### DIFF
--- a/setup-files/terraform/compute-target/setup/compute-target.tf
+++ b/setup-files/terraform/compute-target/setup/compute-target.tf
@@ -48,12 +48,12 @@ data "aws_security_group" "target-sg" {
 
 
 resource "aws_iam_instance_profile" "ec2access" {
-  name  = "ec2acess"
+  name  = "ec2access"
   role = "${aws_iam_role.ec2accessrole.name}"
 }
 
 resource "aws_iam_role" "ec2accessrole" {
-  name = "ec2acess"
+  name = "ec2access"
   path = "/"
 
   assume_role_policy = <<EOF


### PR DESCRIPTION
Terraform script had a typo in it that was frustrating when I was trying to manually delete a role in the AWS console and it took me 5 minutes to figure out that i was spelling "access" wrong.